### PR TITLE
Fix crash when selecting first contact in the list

### DIFF
--- a/Interview/Scenes/ListContacts/Views/ListContactsViewController.swift
+++ b/Interview/Scenes/ListContacts/Views/ListContactsViewController.swift
@@ -95,7 +95,7 @@ class ListContactsViewController: UIViewController, UITableViewDataSource, UITab
     }
     
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        let contato = contacts[indexPath.row - 1]
+        let contato = contacts[indexPath.row]
         
         guard isLegacy(contact: contato) else {
             let alert = UIAlertController(title: "Você tocou em", message: "\(contato.name)", preferredStyle: .alert)

--- a/InterviewUITests/Extensions/XCUIApplication+Asserts.swift
+++ b/InterviewUITests/Extensions/XCUIApplication+Asserts.swift
@@ -8,7 +8,26 @@
 import XCTest
 
 extension XCUIApplication {
-    func shoulDisplayScreenWithTitle(_ title: String) {
-        navigationBars.staticTexts[title].shouldDisplay("screen title '\(title)'")
+
+    @discardableResult
+    func shouldDisplayScreenWithTitle(_ title: String) -> XCUIElement {
+        let uiElement = navigationBars.staticTexts[title]
+        uiElement.shouldDisplay("screen title '\(title)'")
+        return uiElement
+    }
+
+    @discardableResult
+    func shouldDisplayAlertWithTitle(_ title: String) -> XCUIElement {
+        let uiElement = alerts[title]
+        uiElement.shouldDisplay("alert with title '\(title)'")
+        return uiElement
+    }
+
+    @discardableResult
+    func clickOnCellWithText(_ text: String) -> XCUIElement {
+        let uiElement = tables.cells.staticTexts[text]
+        uiElement.shouldDisplay("cell with text '\(text)'")
+        uiElement.tap()
+        return uiElement
     }
 }

--- a/InterviewUITests/Extensions/XCUIElement+Asserts.swift
+++ b/InterviewUITests/Extensions/XCUIElement+Asserts.swift
@@ -8,7 +8,22 @@
 import XCTest
 
 extension XCUIElement {
+
     func shouldDisplay(_ description: String) {
         XCTAssertTrue(waitForExistence(timeout: 5), "It should be display \(description)")
+    }
+
+    @discardableResult
+    func withText(_ text: String) -> XCUIElement {
+        let uiElement = staticTexts[text]
+        uiElement.shouldDisplay("text '\(text)'")
+        return self
+    }
+
+    @discardableResult
+    func withButton(title: String) -> XCUIElement {
+        let uiElement = buttons[title]
+        uiElement.shouldDisplay("button with title '\(title)'")
+        return self
     }
 }

--- a/InterviewUITests/ListContacts/ListContactsUITests.swift
+++ b/InterviewUITests/ListContacts/ListContactsUITests.swift
@@ -17,9 +17,21 @@ class ListContactsUITests: XCTestCase {
     }
 
     //    Given that I launch the application
-    //    When I go to ListContacts screen
+    //    When I go to contact list screen
     //    Then It should display the screen title
     func test_showScreenTitle() throws {
-        app.shoulDisplayScreenWithTitle("Lista de contatos") 
+        app.shouldDisplayScreenWithTitle("Lista de contatos") 
+    }
+
+
+    //    Given I open the contact list screen
+    //    When I click on the first contact's name in the list
+    //    Then It should display an alert with the contact's name
+    func test_selectFirstContactFromList() throws {
+        let contactName = "Shakira"
+        app.clickOnCellWithText(contactName)
+        app.shouldDisplayAlertWithTitle("Você tocou em")
+            .withText(contactName)
+            .withButton(title: "OK")
     }
 }


### PR DESCRIPTION
Create an UI test to select the first contact from list
Fix crash when selecting first contact in the list